### PR TITLE
ci: add metrics github action job

### DIFF
--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -1,0 +1,38 @@
+name: Metrics
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  metrics:
+    name: Metrics
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: GitHub metrics as SVG image
+        uses: lowlighter/metrics@v3.34
+        with:
+          config_timezone: Europe/Paris
+          plugin_achievements: 'yes'
+          plugin_achievements_limit: 0
+          plugin_achievements_secrets: 'yes'
+          plugin_activity: 'yes'
+          plugin_followup: 'yes'
+          plugin_followup_sections: repositories, user
+          plugin_languages: 'yes'
+          plugin_languages_details: bytes-size, percentage
+          plugin_notable: 'yes'
+          plugin_notable_filter: stars:>1000
+          plugin_notable_repositories: 'yes'
+          plugin_stargazers: 'yes'
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to generate and display repository metrics as an SVG image. The workflow is scheduled to run daily, on pushes to the `main` branch, or when manually triggered.

### New GitHub Actions Workflow:
* [`.github/workflows/metrics.yaml`](diffhunk://#diff-49ad1c26b0fb63f6c508a9c80b664390f9559c52e6f154039f288883c8446438R1-R38): Added a `Metrics` workflow that uses the `lowlighter/metrics` action to generate a metrics SVG image. The workflow includes plugins for achievements, activity, follow-up, languages, notable repositories, and stargazers, and is configured to run on a daily schedule, on `main` branch pushes, or via manual dispatch.