### PR TITLE
ci: push metrics output to separate branch

### DIFF
--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: lowlighter/metrics@v3.34
         with:
           committer_branch: output
+          committer_token: ${{ steps.app_token.outputs.token }}
           config_timezone: Europe/Paris
           plugin_achievements: 'yes'
           plugin_achievements_limit: 0


### PR DESCRIPTION
## Summary
- Add `committer_branch: output` so the generated SVG is pushed to an unprotected `output` branch instead of `main`
- Avoids branch protection rule violations that have been breaking the metrics job since September 2025

## Test plan
- [ ] Trigger the metrics workflow manually after merge
- [ ] Verify the `output` branch is created with the generated SVG