### PR TITLE
ci: create output branch before metrics generation

### DIFF
--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -26,6 +26,17 @@ jobs:
           application_id: ${{ secrets.METRICS_APP_ID }}
           application_private_key: ${{ secrets.METRICS_APP_PRIVATE_KEY }}
 
+      - name: Create output branch if missing
+        run: |
+          if ! git ls-remote --exit-code --heads origin output >/dev/null 2>&1; then
+            git switch --orphan output
+            git commit --allow-empty -m "init output branch"
+            git push origin output
+            git switch -
+          fi
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+
       - name: Generate metrics SVG
         uses: lowlighter/metrics@v3.34
         with:


### PR DESCRIPTION
## Summary
- Create the `output` orphan branch on first run if it doesn't exist
- Fixes 404 error when the metrics action tries to push to a non-existent branch

## Context
The metrics action fails with `Not Found` when looking up `refs/heads/output` because the branch was never created. This step bootstraps it.

## Test plan
- [ ] Trigger metrics workflow manually after merge
- [ ] Verify the `output` branch is created and SVG is pushed