### PR TITLE
ci: set git identity for output branch creation

### DIFF
--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -29,6 +29,8 @@ jobs:
       - name: Create output branch if missing
         run: |
           if ! git ls-remote --exit-code --heads origin output >/dev/null 2>&1; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git switch --orphan output
             git commit --allow-empty -m "init output branch"
             git push origin output


### PR DESCRIPTION
## Summary
- Set `user.name` and `user.email` before creating the output branch
- Fixes `fatal: empty ident name` error on the GitHub Actions runner

## Test plan
- [ ] Trigger metrics workflow manually after merge
- [ ] Verify the `output` branch is created and SVG is pushed