### PR TITLE
ci: fix orphan branch switch-back in metrics job

### DIFF
--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -34,7 +34,6 @@ jobs:
             git switch --orphan output
             git commit --allow-empty -m "init output branch"
             git push origin output
-            git switch -
           fi
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}


### PR DESCRIPTION
## Summary
- Remove `git switch -` after creating the orphan output branch
- The previous branch reference doesn't exist after `git switch --orphan`, causing `fatal: invalid reference: @{-1}`
- Switching back is unnecessary since the metrics action manages its own git operations

## Test plan
- [ ] Trigger metrics workflow manually after merge